### PR TITLE
fix(scripts): remove unused texture download scripts from package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "nasa-hecate",
       "version": "0.0.0",
-      "hasInstallScript": true,
       "dependencies": {
         "@react-three/drei": "^10.7.6",
         "@react-three/fiber": "^9.3.0",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview",
-    "setup": "bash scripts/download-textures.sh",
-    "postinstall": "bash scripts/download-textures.sh"
+    "preview": "vite preview"
   },
   "dependencies": {
     "@react-three/drei": "^10.7.6",


### PR DESCRIPTION
  - Remove setup and postinstall scripts that reference deleted download script
  - Textures are now committed directly in the repository